### PR TITLE
Allow showing internet lines when fully zoomed out zoomlevel: 2

### DIFF
--- a/web/src/style/style_oim_telecoms.js
+++ b/web/src/style/style_oim_telecoms.js
@@ -8,7 +8,7 @@ const layers = [
     id: 'telecoms_line',
     type: 'line',
     source: 'openinframap',
-    minzoom: 3,
+    minzoom: 2,
     'source-layer': 'telecoms_communication_line',
     paint: {
       'line-color': '#61637A',


### PR DESCRIPTION
The limit on minzoom: 3 is mostly an artificial limit as it is fully possible to see the whole world and all telecom lines depending on what screen resolution people are using

Reason for setting minzoom at 2 -> maxzoom is currently defined to 2 in the app. So in reality we could just remove minzoom setting for telecoms_line

4k monitor on zoomLevel 3 with zoom on browser on 50% will produce mostly the same result as zoomlevel 2 will do
![image](https://user-images.githubusercontent.com/5204006/150167561-b0c262f3-70e8-46bf-a8d6-9c159c6515c9.png)
