### PR TITLE
Add SQL script to clean views

### DIFF
--- a/schema/views_clean.sql
+++ b/schema/views_clean.sql
@@ -1,0 +1,5 @@
+DROP VIEW IF EXISTS substation;
+DROP MATERIALIZED VIEW IF EXISTS power_substation_relation;
+
+DROP VIEW IF EXISTS power_plant;
+DROP MATERIALIZED VIEW IF EXISTS power_plant_relation;


### PR DESCRIPTION
When reloading data with imposm, recreating tables and functions requires to drop existing views.

This script provides the necessary logic to process accordingly in such an import script :
```sql
# Views cleanup
psql -d $psqlconnstr -f ./schema/functions.sql
psql -d $psqlconnstr -f ./schema/views_clean.sql

# Imposm3 import
docker run --rm --name=imposm_import -v /opt/openinframap/imposm3:/opt/imposm3 -v /data/files/imposm3:/data/files/imposm3 oim/imposm3:latest import -connection $psqlconnstr -deployproduction -config /opt/imposm3/imposm.conf -read /data/files/imposm3/osm.pbf -write -optimize -overwritecache -diff

# Views install
psql -d $psqlconnstr -f ./schema/views.sql
```

Best regards