### PR TITLE
Improve friendly names and add icons to infopopup

### DIFF
--- a/web/src/friendlyicons.ts
+++ b/web/src/friendlyicons.ts
@@ -1,0 +1,11 @@
+// @ts-expect-error Vite virtual module
+import { manifest } from 'virtual:render-svg'
+
+// Map layers icons to show in the infobox
+const friendlyIcons: { [key: string]: string } = {
+  power_transformer: manifest['svg']['power_transformer'],
+  power_tower: manifest['svg']['power_tower'],
+  power_pole: manifest['svg']['power_pole'],
+}
+
+export default friendlyIcons

--- a/web/src/friendlyicons.ts
+++ b/web/src/friendlyicons.ts
@@ -5,7 +5,7 @@ import { manifest } from 'virtual:render-svg'
 const friendlyIcons: { [key: string]: string } = {
   power_transformer: manifest['svg']['power_transformer'],
   power_tower: manifest['svg']['power_tower'],
-  power_pole: manifest['svg']['power_pole'],
+  power_pole: manifest['svg']['power_pole']
 }
 
 export default friendlyIcons

--- a/web/src/friendlynames.ts
+++ b/web/src/friendlynames.ts
@@ -1,4 +1,5 @@
 // Map layer names to a descriptive string to show in the infobox
+// These are matched by longest prefix
 const friendlyNames: { [key: string]: string } = {
   power_transformer: 'Transformer',
   power_tower: 'Power tower',
@@ -6,18 +7,11 @@ const friendlyNames: { [key: string]: string } = {
   power_generator: 'Generator',
   power_wind_turbine: 'Wind turbine',
   power_substation: 'Substation',
-  power_substation_point: 'Substation',
   power_switch: 'Switch',
   power_compensator: 'Compensator',
   power_cable: 'Cable',
-  power_line_1: 'Power line',
-  power_line_2: 'Power line',
-  power_line_3: 'Power line',
-  power_line_4: 'Power line',
-  power_line_underground_1: 'Underground power line',
-  power_line_underground_2: 'Underground power line',
-  power_line_underground_3: 'Underground power line',
-  power_line_underground_4: 'Underground power line',
+  power_line: 'Power line',
+  power_line_underground: 'Underground power line',
   power_line_case: 'Underground power line',
   power_line_label: 'Power line',
   power_solar_panel: 'Solar panel',
@@ -26,8 +20,6 @@ const friendlyNames: { [key: string]: string } = {
   telecoms_mast: 'Telecoms mast',
   telecoms_data_center: 'Telecoms building',
   petroleum_pipeline: 'Pipeline',
-  petroleum_pipeline_case: 'Pipeline',
-  petroleum_pipeline_label: 'Pipeline',
   petroleum_well: 'Well',
   water_pipeline: 'Water pipeline'
 }

--- a/web/src/icons/converter.svg
+++ b/web/src/icons/converter.svg
@@ -1,26 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
-  <g id="Layer_1">
-    <g>
-      <path d="M12.5,23.529 C6.377,23.529 1.413,18.578 1.413,12.471 C1.413,6.363 6.377,1.412 12.5,1.412 C18.623,1.412 23.587,6.363 23.587,12.471 C23.587,18.578 18.623,23.529 12.5,23.529 z" fill="#FFFFFF"/>
-      <path d="M12.5,23.529 C6.377,23.529 1.413,18.578 1.413,12.471 C1.413,6.363 6.377,1.412 12.5,1.412 C18.623,1.412 23.587,6.363 23.587,12.471 C23.587,18.578 18.623,23.529 12.5,23.529 z" fill-opacity="0" stroke="#000000" stroke-width="1.8"/>
+<svg width="100%" height="100%" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;">
+    <g transform="matrix(1,0,0,1,0.5,0.313814)">
+        <g id="Layer_1">
+            <g>
+                <g transform="matrix(1,0,0,1,-0.5,-0.284314)">
+                    <path d="M12.5,23.529C6.377,23.529 1.413,18.578 1.413,12.471C1.413,6.363 6.377,1.412 12.5,1.412C18.623,1.412 23.587,6.363 23.587,12.471C23.587,18.578 18.623,23.529 12.5,23.529Z" style="fill:white;fill-rule:nonzero;"/>
+                    <path d="M12.5,23.529C6.377,23.529 1.413,18.578 1.413,12.471C1.413,6.363 6.377,1.412 12.5,1.412C18.623,1.412 23.587,6.363 23.587,12.471C23.587,18.578 18.623,23.529 12.5,23.529Z" style="fill-opacity:0;fill-rule:nonzero;stroke:black;stroke-width:1.8px;"/>
+                </g>
+                <path d="M4.078,20.886L20.848,4.056" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:0.72px;"/>
+            </g>
+        </g>
     </g>
-    <path d="M4.078,20.886 L20.848,4.056" fill-opacity="0" stroke="#000000" stroke-width="0.72"/>
-  </g>
-  <g id="ACDC" display="none">
-    <path d="M5.398,8.106 L5.398,8.106" fill-opacity="0" stroke="#000000" stroke-width="1.2"/>
-    <path d="M0.5,0.5 L0.5,0.5" fill-opacity="0" stroke="#000000" stroke-width="1.2"/>
-    <path d="M6.448,6.816 L6.448,6.816" fill-opacity="0" stroke="#000000" stroke-width="1.2"/>
-    <path d="M12.658,8.409 C12.496,9.649 11.63,10.704 10.363,10.704 C9.095,10.704 8.305,9.861 8.068,8.709 C7.812,7.467 7.04,6.414 5.773,6.414 C4.505,6.414 3.616,7.429 3.478,8.709" fill-opacity="0" stroke="#000000" stroke-width="0.72" stroke-linecap="round"/>
-    <path d="M12.658,15.255 L20.331,15.255" fill-opacity="0" stroke="#000000" stroke-width="0.72"/>
-    <path d="M12.658,17.055 L20.331,17.055" fill-opacity="0" stroke="#000000" stroke-width="0.72" stroke-dasharray="1.44,0.72"/>
-  </g>
-  <g id="ACAC" display="none">
-    <path d="M5.398,8.106 L5.398,8.106" fill-opacity="0" stroke="#000000" stroke-width="1.2"/>
-    <path d="M0.5,0.5 L0.5,0.5" fill-opacity="0" stroke="#000000" stroke-width="1.2"/>
-    <path d="M6.448,6.816 L6.448,6.816" fill-opacity="0" stroke="#000000" stroke-width="1.2"/>
-    <path d="M12.658,8.409 C12.496,9.649 11.63,10.704 10.363,10.704 C9.095,10.704 8.305,9.861 8.068,8.709 C7.812,7.467 7.04,6.414 5.773,6.414 C4.505,6.414 3.616,7.429 3.478,8.709" fill-opacity="0" stroke="#000000" stroke-width="0.72" stroke-linecap="round"/>
-    <path d="M20.848,17.309 C20.686,18.55 19.82,19.604 18.553,19.604 C17.285,19.604 16.495,18.761 16.258,17.609 C16.002,16.368 15.23,15.314 13.963,15.314 C12.695,15.314 11.806,16.33 11.668,17.609" fill-opacity="0" stroke="#000000" stroke-width="0.72" stroke-linecap="round"/>
-  </g>
 </svg>

--- a/web/src/icons/power_pole.svg
+++ b/web/src/icons/power_pole.svg
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="10" height="10" viewBox="0, 0, 10, 10">
-  <g id="Layer_1">
-    <path d="M5.5,9.969 C3.032,9.969 1.031,7.968 1.031,5.5 C1.031,3.032 3.032,1.031 5.5,1.031 C7.968,1.031 9.969,3.032 9.969,5.5 C9.969,7.968 7.968,9.969 5.5,9.969 z" fill="#775211"/>
-    <g>
-      <path d="M5.5,9.969 C3.032,9.969 1.031,7.968 1.031,5.5 C1.031,3.032 3.032,1.031 5.5,1.031 C7.968,1.031 9.969,3.032 9.969,5.5 C9.969,7.968 7.968,9.969 5.5,9.969 z" fill="#775211"/>
-      <path d="M5.5,9.969 C3.032,9.969 1.031,7.968 1.031,5.5 C1.031,3.032 3.032,1.031 5.5,1.031 C7.968,1.031 9.969,3.032 9.969,5.5 C9.969,7.968 7.968,9.969 5.5,9.969 z" fill-opacity="0" stroke="#000000" stroke-width="1"/>
+<svg width="100%" height="100%" viewBox="0 0 10 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;">
+    <g transform="matrix(1,0,0,1,-0.5,-0.5)">
+        <g id="Layer_1">
+            <g>
+                <path d="M5.5,9.969C3.032,9.969 1.031,7.968 1.031,5.5C1.031,3.032 3.032,1.031 5.5,1.031C7.968,1.031 9.969,3.032 9.969,5.5C9.969,7.968 7.968,9.969 5.5,9.969Z" style="fill:rgb(119,82,17);fill-rule:nonzero;"/>
+                <path d="M5.5,9.969C3.032,9.969 1.031,7.968 1.031,5.5C1.031,3.032 3.032,1.031 5.5,1.031C7.968,1.031 9.969,3.032 9.969,5.5C9.969,7.968 7.968,9.969 5.5,9.969Z" style="fill-opacity:0;fill-rule:nonzero;stroke:rgb(46,46,46);stroke-width:1px;"/>
+            </g>
+        </g>
     </g>
-  </g>
 </svg>

--- a/web/src/icons/power_transformer.svg
+++ b/web/src/icons/power_transformer.svg
@@ -1,16 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="14.173" height="22.11" viewBox="0, 0, 14.173, 22.11">
-  <g id="Layer_1">
-    <g>
-      <path d="M7.625,22 C3.966,22 1,19.034 1,15.375 C1,11.716 3.966,8.75 7.625,8.75 C11.284,8.75 14.25,11.716 14.25,15.375 C14.25,19.034 11.284,22 7.625,22 z" fill="#FFFFFF"/>
-      <path d="M7.625,22 C3.966,22 1,19.034 1,15.375 C1,11.716 3.966,8.75 7.625,8.75 C11.284,8.75 14.25,11.716 14.25,15.375 C14.25,19.034 11.284,22 7.625,22 z" fill-opacity="0" stroke="#3B3B3B" stroke-width="1"/>
+<svg width="100%" height="100%" viewBox="0 0 15 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;">
+    <g id="Layer_1" transform="matrix(1,0,0,1,0.4135,-0.055)">
+        <g transform="matrix(1,0,0,1,-0.5385,-0.601)">
+            <path d="M7.625,22C3.966,22 1,19.034 1,15.375C1,11.716 3.966,8.75 7.625,8.75C11.284,8.75 14.25,11.716 14.25,15.375C14.25,19.034 11.284,22 7.625,22Z" style="fill:white;fill-rule:nonzero;"/>
+            <path d="M7.625,22C3.966,22 1,19.034 1,15.375C1,11.716 3.966,8.75 7.625,8.75C11.284,8.75 14.25,11.716 14.25,15.375C14.25,19.034 11.284,22 7.625,22Z" style="fill-opacity:0;fill-rule:nonzero;stroke:rgb(59,59,59);stroke-width:1px;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,-0.5385,-0.601)">
+            <path d="M7.625,14.562C3.966,14.562 1,11.596 1,7.938C1,4.279 3.966,1.312 7.625,1.312C11.284,1.312 14.25,4.279 14.25,7.938C14.25,11.596 11.284,14.562 7.625,14.562Z" style="fill:white;fill-rule:nonzero;"/>
+            <path d="M7.625,14.562C3.966,14.562 1,11.596 1,7.938C1,4.279 3.966,1.312 7.625,1.312C11.284,1.312 14.25,4.279 14.25,7.938C14.25,11.596 11.284,14.562 7.625,14.562Z" style="fill-opacity:0;fill-rule:nonzero;stroke:rgb(59,59,59);stroke-width:1px;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,-0.5385,-0.601)">
+            <path d="M7.625,22C3.966,22 1,19.034 1,15.375C1,11.716 3.966,8.75 7.625,8.75C11.284,8.75 14.25,11.716 14.25,15.375C14.25,19.034 11.284,22 7.625,22Z" style="fill:white;fill-opacity:0;fill-rule:nonzero;"/>
+            <path d="M7.625,22C3.966,22 1,19.034 1,15.375C1,11.716 3.966,8.75 7.625,8.75C11.284,8.75 14.25,11.716 14.25,15.375C14.25,19.034 11.284,22 7.625,22Z" style="fill-opacity:0;fill-rule:nonzero;stroke:rgb(59,59,59);stroke-width:1px;"/>
+        </g>
     </g>
-    <g>
-      <path d="M7.625,14.562 C3.966,14.562 1,11.596 1,7.938 C1,4.279 3.966,1.312 7.625,1.312 C11.284,1.312 14.25,4.279 14.25,7.938 C14.25,11.596 11.284,14.562 7.625,14.562 z" fill="#FFFFFF"/>
-      <path d="M7.625,14.562 C3.966,14.562 1,11.596 1,7.938 C1,4.279 3.966,1.312 7.625,1.312 C11.284,1.312 14.25,4.279 14.25,7.938 C14.25,11.596 11.284,14.562 7.625,14.562 z" fill-opacity="0" stroke="#3B3B3B" stroke-width="1"/>
-    </g>
-    <path d="M10.288,2.188" fill-opacity="0" stroke="#3B3B3B" stroke-width="1"/>
-    <path d="M7.625,22 C3.966,22 1,19.034 1,15.375 C1,11.716 3.966,8.75 7.625,8.75 C11.284,8.75 14.25,11.716 14.25,15.375 C14.25,19.034 11.284,22 7.625,22 z" fill-opacity="0" stroke="#3B3B3B" stroke-width="1"/>
-  </g>
 </svg>

--- a/web/src/infopopup.css
+++ b/web/src/infopopup.css
@@ -1,18 +1,26 @@
 table.item_info th {
-	text-align: left;
+  text-align: left;
 }
 
 .oim-info h3 {
+  font-size: 18px;
   margin-top: 0px;
-  margin-bottom: 0px;
+  margin-bottom: 5px;
+}
+
+.oim-info h3 img {
+  max-height: 16px;
+  position: relative;
+  top: 1px;
+  margin-right: 0.3em;
 }
 
 .oim-info h4::before {
-  content: "("
+  content: '(';
 }
 
 .oim-info h4::after {
-  content: ")"
+  content: ')';
 }
 
 .oim-info h4 {
@@ -23,6 +31,7 @@ table.item_info th {
 
 .wikidata_image {
   border: 1px solid #ddd;
+  max-height: 150px;
 }
 
 div.ext_link {
@@ -37,7 +46,7 @@ span.voltages {
 }
 
 div.wikidata_link {
-background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='156' width='156'%3E%3Ccircle r='70' stroke='%23FFF' cy='78' cx='78' stroke-width='12' fill='%23E6E6E6'/%3E%3Ccircle cy='78' cx='78' r='56' fill='%23FFF'/%3E%3Cpath d='M32 107h3V49h-3v58zm7 0h10V49H39v58zm13-58v58h10V49H52z' fill='%23900'/%3E%3Cpath d='M114 107h3V49h-3v58zm7-58v58h3V49h-3zm-55 58h3V49h-3v58zm7-58v58h3V49h-3z' fill='%23396'/%3E%3Cpath d='M80 107h10V49H80v58zm13 0h4V49h-4v58zm7-58v58h10V49h-10z' fill='%23069'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='156' width='156'%3E%3Ccircle r='70' stroke='%23FFF' cy='78' cx='78' stroke-width='12' fill='%23E6E6E6'/%3E%3Ccircle cy='78' cx='78' r='56' fill='%23FFF'/%3E%3Cpath d='M32 107h3V49h-3v58zm7 0h10V49H39v58zm13-58v58h10V49H52z' fill='%23900'/%3E%3Cpath d='M114 107h3V49h-3v58zm7-58v58h3V49h-3zm-55 58h3V49h-3v58zm7-58v58h3V49h-3z' fill='%23396'/%3E%3Cpath d='M80 107h10V49H80v58zm13 0h4V49h-4v58zm7-58v58h10V49h-10z' fill='%23069'/%3E%3C/svg%3E");
 }
 
 div.wikipedia_link {
@@ -60,5 +69,5 @@ div.commons_link {
   background-size: 25px 25px;
   background-repeat: no-repeat;
   padding-bottom: 3px;
-background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='-305 -516 610 820'%3E%3Cdefs%3E%3CclipPath id='a'%3E%3Ccircle r='298'/%3E%3C/clipPath%3E%3C/defs%3E%3Ccircle cy='-16.1' r='85.2' fill='%23900'/%3E%3Cg fill='%23069' transform='translate(0 -16) scale(.85192)'%3E%3Cg id='b' clip-path='url(%23a)'%3E%3Cpath d='M-11 180v118h22V180'/%3E%3Cpath d='M-43 185l43-75 43 75'/%3E%3C/g%3E%3Cg id='c'%3E%3Cuse width='100%25' height='100%25' transform='rotate(45)' xlink:href='%23b'/%3E%3Cuse width='100%25' height='100%25' transform='rotate(90)' xlink:href='%23b'/%3E%3Cuse width='100%25' height='100%25' transform='rotate(135)' xlink:href='%23b'/%3E%3C/g%3E%3Cuse width='100%25' height='100%25' transform='scale(-1 1)' xlink:href='%23c'/%3E%3Cpath fill='none' stroke='%23069' stroke-width='84' d='M-181-181a256 256 0 10362 0C110-252 4-216-18-371'/%3E%3Cpath d='M-23-515s-36 135-80 185 116-62 170-5-90-180-90-180z'/%3E%3C/g%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='-305 -516 610 820'%3E%3Cdefs%3E%3CclipPath id='a'%3E%3Ccircle r='298'/%3E%3C/clipPath%3E%3C/defs%3E%3Ccircle cy='-16.1' r='85.2' fill='%23900'/%3E%3Cg fill='%23069' transform='translate(0 -16) scale(.85192)'%3E%3Cg id='b' clip-path='url(%23a)'%3E%3Cpath d='M-11 180v118h22V180'/%3E%3Cpath d='M-43 185l43-75 43 75'/%3E%3C/g%3E%3Cg id='c'%3E%3Cuse width='100%25' height='100%25' transform='rotate(45)' xlink:href='%23b'/%3E%3Cuse width='100%25' height='100%25' transform='rotate(90)' xlink:href='%23b'/%3E%3Cuse width='100%25' height='100%25' transform='rotate(135)' xlink:href='%23b'/%3E%3C/g%3E%3Cuse width='100%25' height='100%25' transform='scale(-1 1)' xlink:href='%23c'/%3E%3Cpath fill='none' stroke='%23069' stroke-width='84' d='M-181-181a256 256 0 10362 0C110-252 4-216-18-371'/%3E%3Cpath d='M-23-515s-36 135-80 185 116-62 170-5-90-180-90-180z'/%3E%3C/g%3E%3C/svg%3E");
 }

--- a/web/src/infopopup.ts
+++ b/web/src/infopopup.ts
@@ -6,6 +6,7 @@ import { titleCase } from 'title-case'
 import browserLanguage from 'in-browser-language'
 import { local_name_tags } from './l10n.ts'
 import friendlyNames from './friendlynames.ts'
+import friendlyIcons from './friendlyicons.ts'
 import { el, mount, setChildren, RedomElement } from 'redom'
 
 const hidden_keys = [
@@ -77,6 +78,22 @@ class InfoPopup {
     })
   }
 
+  friendlyRender(label: string){
+    if (label in friendlyNames) {
+      return friendlyNames[label]
+    } else {
+      return label;
+    }
+  }
+
+  friendlyIcon(feature: string){
+    if (feature in friendlyIcons) {
+      return friendlyIcons[feature]
+    } else {
+      return null;
+    }
+  }
+
   renderKey(key: string, value: any) {
     if (hidden_keys.includes(key) || key.startsWith('name_') || key.startsWith('voltage') || !value) {
       return null
@@ -106,7 +123,7 @@ class InfoPopup {
       })
       key = 'Website'
     } else {
-      key = titleCase(key)
+      key = titleCase(this.friendlyRender(key))
     }
 
     return el('tr', el('th', key), el('td', value))
@@ -123,15 +140,16 @@ class InfoPopup {
     }
 
     if (!title_text) {
-      const layer_id = feature.layer['id']
-      if (layer_id in friendlyNames) {
-        title_text = friendlyNames[layer_id]
-      } else {
-        title_text = feature.layer['id']
-      }
+      title_text = this.friendlyRender(feature.layer['id']);
     }
 
-    const container = el('div.nameContainer', el('h3', title_text))
+    let feature_title = el('h3', title_text);
+    let feature_iconpath = this.friendlyIcon(feature.layer['id']);
+    if (feature_iconpath != null){
+      feature_title = el('h3', el('img', {src: feature_iconpath, height: 35}), title_text);
+    }
+
+    const container = el('div.nameContainer', el('h3', feature_title))
 
     // If we're showing a translated name, also show the name tag
     if (feature.properties.name && title_text != feature.properties.name) {

--- a/web/src/infopopup.ts
+++ b/web/src/infopopup.ts
@@ -78,19 +78,19 @@ class InfoPopup {
     })
   }
 
-  friendlyRender(label: string){
+  friendlyRender(label: string) {
     if (label in friendlyNames) {
       return friendlyNames[label]
     } else {
-      return label;
+      return label
     }
   }
 
-  friendlyIcon(feature: string){
+  friendlyIcon(feature: string) {
     if (feature in friendlyIcons) {
       return friendlyIcons[feature]
     } else {
-      return null;
+      return null
     }
   }
 
@@ -140,13 +140,13 @@ class InfoPopup {
     }
 
     if (!title_text) {
-      title_text = this.friendlyRender(feature.layer['id']);
+      title_text = this.friendlyRender(feature.layer['id'])
     }
 
-    let feature_title = el('h3', title_text);
-    let feature_iconpath = this.friendlyIcon(feature.layer['id']);
-    if (feature_iconpath != null){
-      feature_title = el('h3', el('img', {src: feature_iconpath, height: 35}), title_text);
+    let feature_title = el('h3', title_text)
+    const feature_iconpath = this.friendlyIcon(feature.layer['id'])
+    if (feature_iconpath != null) {
+      feature_title = el('h3', el('img', {src: feature_iconpath, height: 35}), title_text)
     }
 
     const container = el('div.nameContainer', el('h3', feature_title))

--- a/web/src/infopopup.ts
+++ b/web/src/infopopup.ts
@@ -146,7 +146,7 @@ class InfoPopup {
     let feature_title = el('h3', title_text)
     const feature_iconpath = this.friendlyIcon(feature.layer['id'])
     if (feature_iconpath != null) {
-      feature_title = el('h3', el('img', {src: feature_iconpath, height: 35}), title_text)
+      feature_title = el('h3', el('img', { src: feature_iconpath, height: 35 }), title_text)
     }
 
     const container = el('div.nameContainer', el('h3', feature_title))

--- a/web/src/infopopup.ts
+++ b/web/src/infopopup.ts
@@ -79,11 +79,15 @@ class InfoPopup {
   }
 
   friendlyRender(label: string) {
-    if (label in friendlyNames) {
-      return friendlyNames[label]
-    } else {
-      return label
+    let friendlyName = label
+    let prefixLen = 0
+    for (const name in friendlyNames) {
+      if (label.startsWith(name) && name.length > prefixLen) {
+        friendlyName = friendlyNames[name]
+        prefixLen = name.length
+      }
     }
+    return friendlyName
   }
 
   friendlyIcon(feature: string) {
@@ -149,7 +153,7 @@ class InfoPopup {
       feature_title = el('h3', el('img', { src: feature_iconpath, height: 35 }), title_text)
     }
 
-    const container = el('div.nameContainer', el('h3', feature_title))
+    const container = el('div.nameContainer', feature_title)
 
     // If we're showing a translated name, also show the name tag
     if (feature.properties.name && title_text != feature.properties.name) {


### PR DESCRIPTION
This improvement allows to :
* Define more friendly names, particularly for infopopup keys in addition to existing process for features' name.
* Define icons displayed beside the feature's name on infopopup.

This PR comes with icons for 3 features as an example: power tower, power pole and power transformer.

It is currently implemented on a fork and gives such results:
![image](https://github.com/user-attachments/assets/e315b34d-d021-4263-be14-a55c7cfad2a0)
Keys are respectively named `fibre_adresse`, `fibre_imb`, `fibre_imb_cat`, `fibre_imb_etat`, `fibre_imb_type` which is pretty meaningless and need to be improved, just like some OSM keys names.

Icons may also be useful at some point, sourced from sprites or from custom URL in the same `friendlyicons.ts` file.

Cheers!