### PR TITLE
Update infopopup.ts

### DIFF
--- a/web/src/infopopup.ts
+++ b/web/src/infopopup.ts
@@ -184,7 +184,7 @@ function formatFrequency(value: number | number[]): string {
 function formatPower(value: number): string {
   const formatter = new Intl.NumberFormat(i18next.language, { maximumFractionDigits: 2 })
   if (value < 1) {
-    return formatter.format(value * 1000) + ' ' + t('units.kV', 'kV')
+    return formatter.format(value * 1000) + ' ' + t('units.kW', 'kW')
   } else {
     return formatter.format(value) + ' ' + t('units.MW', 'MW')
   }


### PR DESCRIPTION
Fix units when displaying power in infopopup.

Current state is: Units of "kV" are displayed for power of generators below 1MW. But "kV" is not a unit of power and the value displayed is what is contained in OSM data as "kW"

![grafik](https://github.com/user-attachments/assets/cd999f8f-5c6e-41eb-90ea-113f6aae14d0)

In openstreetmap:
![grafik](https://github.com/user-attachments/assets/8fc89a7c-9112-4f29-a689-0bc8001674ca)

Likely this was a copy+paste error when internationalization was enabled.