### PR TITLE
Sticky footer and country list table header

### DIFF
--- a/web-backend/static/main.css
+++ b/web-backend/static/main.css
@@ -64,6 +64,10 @@ footer {
   padding: 8px 8px;
   font-size: 0.8rem;
   background-color: #fafafa;
+  @media only screen and (min-width: 1024px) {
+      bottom: 0px;
+      position: sticky;
+  }
 }
 
 footer > * + * {

--- a/web-backend/templates/plants_country.html
+++ b/web-backend/templates/plants_country.html
@@ -28,7 +28,7 @@
       {% if min_output %}with output greater than {{min_output|power}}{% endif %}
       {% if construction %}under construction{% endif %}
         in {{country|country_name}}</caption>
-    <thead>
+    <thead style="position: sticky;top: -1px">
       <tr>
         <th style="width: 300px">Name</th>
         {%- if english_name %}


### PR DESCRIPTION
To improve table readability particularly for first time consumers of the country plant list page the table header will stick to the top when scrolling down. This only affects non-mobile views since on mobile a non table layout is used. Also added on desktop screens the footer to be sticky to improve visibilty of export options and OSM license.

Demo video: [Sticky table header and footer  demo.webm](https://github.com/user-attachments/assets/b0ef567a-6cc5-41c4-9657-a6cdc6740224)