### PR TITLE
PUDL renamed their table -- update link

### DIFF
--- a/web-backend/templates/plant_detail.html
+++ b/web-backend/templates/plant_detail.html
@@ -78,7 +78,7 @@
       <td><a href="https://wiki.openstreetmap.org/wiki/Key:{{tag}}">{{tag}}</a></td>
       <td>
         {% if tag == "ref:US:EIA" %}
-          <a href="https://data.catalyst.coop/pudl/plants_entity_eia/{{value}}">{{value}}</a>
+          <a href="https://data.catalyst.coop/pudl/core_eia__entity_plants/{{value}}">{{value}}</a>
         {% elif tag == "repd:id" %}
           <a href="https://repd.russss.dev/repd/repd/{{value}}">{{value}}</a>
         {% else %}


### PR DESCRIPTION
PUDL renamed their table plants_entity_eia to core_eia__entity_plants , so the link needs to be updated.