### PR TITLE
Migrate to new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -1,3 +1,10 @@
+---
+name: Issue
+about: Create an issue to suggest a feature or report a bug
+title: ""
+labels: ""
+assignees: ""
+---
 If you're reporting an issue with rendering, please provide:
 
 ### Screenshot

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: false


### PR DESCRIPTION
This PR migrate to new issue template:
- Create new directory
- Add header to support new issue template
- Add config.yml to disable blank issue

After
![Screenshot_20250410-084643](https://github.com/user-attachments/assets/73da70e0-c91a-4531-ab67-46252aeb473b)

More details here
- https://docs.github.com/articles/about-issue-and-pull-request-templates
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser