### PR TITLE
Fix circuit lookup for relation-based substations

### DIFF
--- a/web-backend/src/views/api.py
+++ b/web-backend/src/views/api.py
@@ -44,7 +44,9 @@ class SubstationResponse(BaseModel):
 async def substation(request: Request) -> SubstationResponse:
     """Fetch circuit metadata for a substation."""
     database = get_db(request)
-    substation_id = path_param(request, "substation_id", int)
+    # Imposm uses negative IDs for OSM relations in geometry tables, while
+    # relation member references retain the original positive OSM ID.
+    substation_id = abs(path_param(request, "substation_id", int))
     res = await database.execute(
         text(
             """SELECT relation.osm_id AS relation_id,


### PR DESCRIPTION
## Problem

Some substations, particularly those mapped as multipolygon relations, do not display their circuits when clicked, even though they belong to circuit relations in OpenStreetMap.

The issue may affect any substation represented by an OSM relation, not only multipolygons.

## Example

This [multipolygon substation](https://openinframap.org/#16.75/42.890897/-8.532621) reproduces the issue.

## Root cause

Imposm represents OSM relation IDs as negative values in geometry tables, while circuit relation member references retain the original positive OSM ID. The API therefore looked up the circuit memberships using the wrong ID.

## Fix

Normalize substation IDs before looking up their circuit memberships.

## Impact

Relation-based substations now show their circuit memberships in the same way as other substations.

## Validation

An A/B integration test was run against the same local PostGIS database, populated by Imposm from a real Galicia OSM extract:

| Backend | Substation ID | Result |
| --- | ---: | --- |
| `main` | `-11311505` | No circuits |
| `main` | `11311505` | 2 circuits |
| This PR | `-11311505` | 2 circuits |
| This PR | `11311505` | 2 circuits |

The two requests against this PR returned the same circuit memberships.

- `uv run ruff check src/views/api.py`
- `uv run mypy .`

No automated tests were added because the backend does not currently have a test suite.
